### PR TITLE
Fix for new spelling package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,7 @@ Description: An implementation of two functions that estimate values for percent
 Depends: R (>= 3.4.0)
 License: MIT + file LICENSE
 Encoding: UTF-8
+Language: en-GB
 LazyData: true
 RoxygenNote: 6.0.1
 Imports: magrittr,

--- a/tests/spelling.R
+++ b/tests/spelling.R
@@ -1,1 +1,1 @@
-spelling::spell_check_test(vignettes = TRUE, lang = "en_GB", error = FALSE)
+spelling::spell_check_test(vignettes = TRUE, error = FALSE)


### PR DESCRIPTION
Thank you for using the `spelling` package. The new version spelling 1.1 stores the language in the package `DESCRIPTION` field.